### PR TITLE
Gitignore and a bug fix for make clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+DNA_common/
+*.wgt

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ clean:
 	rm -rf css/user
 	rm -f $(PROJECT).wgt
 	git clean -f
-	-rm -r DNA_common
+	-rm -rf DNA_common
 
 common: /opt/usr/apps/common-apps
 	cp -r /opt/usr/apps/common-apps DNA_common


### PR DESCRIPTION
Hi,

My pull request contains the following changes:
- A bug with make clean if directory DNA_common does exist has been fixed at Makefile
- Gitignore file has been added to skip directory DNA_common and any wgt files when git status is reported.

Best regards,
Leon
